### PR TITLE
fix: use `collections.abc` for python 3.10+ support

### DIFF
--- a/consistent_sampler/consistent_sampler.py
+++ b/consistent_sampler/consistent_sampler.py
@@ -578,7 +578,7 @@ def sampler(id_list,
         or USAGE_EXAMPLES.md
     """
 
-    if not isinstance(id_list, collections.Iterator):
+    if not isinstance(id_list, collections.abc.Iterator):
         assert len(id_list) == len(set(id_list)),\
             "Input id_list to sampler contains duplicate ids: {}"\
             .format(duplicates(id_list))


### PR DESCRIPTION
Per the Python 3.9 docs, `collections` was deprecated in Python 3.3 and was moved to `collections.abc` in Python 3.10:
https://docs.python.org/3.9/library/collections.html